### PR TITLE
typo: use americanformat in american format example

### DIFF
--- a/20 Dataview Queries/Transform date meta data for calculations.md
+++ b/20 Dataview Queries/Transform date meta data for calculations.md
@@ -50,7 +50,7 @@ americanformat:: 09/25/2022 09:09 AM
 
 ```dataview
 TABLE date(regexreplace(americanformat, "([0-9]+)/([0-9]+)/([0-9]+) ([0-9:]+)(.+)", "$3-$1-$2T$4")) AS "date"
-WHERE germanformat
+WHERE americanformat
 ```
 
 ---


### PR DESCRIPTION
Use `americanformat` in "american format" example query, and not `germanformat`.

I guess this PR doesn't (really) matter for this query to work (as both `germanformat` and `americanformat` inline fields are in the same file), but hopefully it adds value to differentiating the queries (or make it clearer).